### PR TITLE
Add markdown link integrity test

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,18 @@
+name: Link Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run link tests
+        run: pytest tests/test_links.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,15 @@ CONTRIBUTING.md            # You are here
    ```
    git checkout -b add-new-pattern
    ```
-3. Commit with a descriptive message:
+3. Test for broken links:
+   ```
+   pytest
+   ```
+4. Commit with a descriptive message:
    ```
    git commit -m "Add [Pattern Name] to [Group]"
    ```
-4. Push and open a pull request.
+5. Push and open a pull request.
 
 ---
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,42 @@
+import re
+from pathlib import Path
+
+# Regex to find links like ](./path#fragment)
+LINK_RE = re.compile(r"\]\((\.\/[^)#\s]+)(?:#([^\)\s]+))?\)")
+
+
+def slugify(text: str) -> str:
+    """Create a GitHub-style anchor slug from a heading."""
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9\s-]", "", text)
+    text = re.sub(r"\s+", "-", text)
+    return text
+
+def heading_slugs(content: str) -> set[str]:
+    slugs = set()
+    for line in content.splitlines():
+        m = re.match(r"^\s*#+\s+(.*)", line)
+        if m:
+            slugs.add(slugify(m.group(1)))
+    return slugs
+
+
+def test_local_links():
+    root = Path(__file__).resolve().parents[1]
+    markdown_files = root.rglob("*.md")
+    errors = []
+
+    for md_file in markdown_files:
+        text = md_file.read_text(encoding="utf-8")
+        for match in LINK_RE.finditer(text):
+            rel_path, fragment = match.groups()
+            target = (md_file.parent / rel_path).resolve()
+            if not target.exists():
+                errors.append(f"{md_file}: missing file {rel_path}")
+                continue
+            if fragment:
+                target_text = target.read_text(encoding="utf-8")
+                if fragment.lower() not in heading_slugs(target_text):
+                    errors.append(f"{md_file}: missing fragment {rel_path}#{fragment}")
+
+    assert not errors, "Broken links:\n" + "\n".join(errors)


### PR DESCRIPTION
## Summary
- add a pytest-based script to verify local Markdown links and fragments
- document running link tests in contributing guide
- check links in CI via GitHub Actions

## Testing
- `pytest tests/test_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68a22b8112488320815a061d71837544