### PR TITLE
docs: add overview to introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ guidelines.
 <summary><strong>📜 Table of Contents</strong></summary>
 
 ### 1. Interaction Patterns 💬
-- [Persona Pattern 🧑‍🎭](./interaction-patterns.md#persona-patern-)
+- [Persona Pattern 🧑‍🎭](./interaction-patterns.md#persona-pattern-)
 - [Audience Persona Pattern 👥](./interaction-patterns.md#audience-persona-pattern-)
 - [Flipped Interaction Pattern 🔄](./interaction-patterns.md#flipped-interaction-pattern-)
 - [Ask for Input Pattern 💌](./interaction-patterns.md#ask-for-input-pattern-)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ guidelines.
 <summary><strong>📜 Table of Contents</strong></summary>
 
 ### 1. Interaction Patterns 💬
-- [Persona Pattern 🧑‍🎭](./interaction-patterns.md#persona-pattern-)
+- [Persona Pattern 🧑‍🎭](./interaction-patterns.md#persona-patern-)
 - [Audience Persona Pattern 👥](./interaction-patterns.md#audience-persona-pattern-)
 - [Flipped Interaction Pattern 🔄](./interaction-patterns.md#flipped-interaction-pattern-)
 - [Ask for Input Pattern 💌](./interaction-patterns.md#ask-for-input-pattern-)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # Prompt Engineering Patterns Handbook
 
 ## Introduction
+
 Prompt engineering is the art of crafting clear, purposeful instructions for large language models (LLMs) like ChatGPT.  
 Done well, it’s less “asking nicely” and more **architecting conversations** so the AI delivers exactly what you need — consistently.
 
 The patterns here are **reusable blueprints**. Each is like a Lego brick: snap them together to build anything from a polite email rewriter to a fully automated AI agent workflow.
+
+### Overview
+
+The Prompt Engineering Patterns Handbook is a Markdown-based guide that
+catalogues reusable prompt-design blueprints for large language models. The
+root directory contains a master `README.md` plus four themed pattern files
+(`interaction-patterns.md`, `structuring-patterns.md`,
+`reasoning-patterns.md`, and `creativity-patterns.md`) alongside contributing
+guidelines.
+
+### Architecture & Concepts
+
+- **Master index** – `README.md` introduces the handbook and lists every
+  pattern, grouped into four categories: Interaction, Structuring, Reasoning &
+  Analysis, and Creativity & Exploration.
+- **Pattern files** – Each category file documents specific patterns using a
+  consistent template: description, purpose, problem solved, data needed, a
+  “quick copy-paste prompt,” and general vs. AI-agent examples.
+- **Contribution workflow** – `CONTRIBUTING.md` outlines how to add a new
+  pattern: choose the correct group file, follow the standard section format,
+  and update the master README catalog.
+
+### Pointers for Further Exploration
+
+1. **Dive into pattern groups**: Start with the README’s “Detailed Guides”
+   links to explore each category in depth.
+2. **Practice with examples**: Try out the “Quick Copy-Paste Prompt” snippets
+   in the pattern files to see how they influence model responses.
+3. **Contribute new patterns**: Follow the contributing guidelines to add or
+   refine patterns, keeping examples and prompts concise.
+4. **Experiment with chaining patterns**: Combine multiple patterns (e.g.,
+   Persona + Template) to build richer, more controllable prompt workflows.
 
 ---
 


### PR DESCRIPTION
## Summary
- expand README introduction with project overview, architecture, and learning pointers

## Testing
- `npx --yes markdownlint-cli README.md` *(fails: line-length, existing formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f6efc96883209f484253e0b8e715